### PR TITLE
Fix install command to use dev-main constraint and --dev flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,13 @@ A comprehensive collection of specialized Claude Code subagents and skills desig
 
 ## Installation
 
-Install the package via Composer:
+Install the package as a dev dependency via Composer:
 
 ```bash
-composer require iserter/laravel-claude-agents
+composer require --dev iserter/laravel-claude-agents:dev-main
 ```
+
+> **Note:** Since this package has no stable release yet, you must specify the `dev-main` version constraint. The `--dev` flag is recommended as this package is only needed during development.
 
 ## Usage
 


### PR DESCRIPTION
## Problem

The current install command `composer require iserter/laravel-claude-agents` fails on projects with `"prefer-stable": true` (which is the Laravel default) because the package has no stable release yet.

## Solution

- Updated the install command to `composer require --dev iserter/laravel-claude-agents:dev-main`
- Added `--dev` flag since this package is only needed during development
- Added a note explaining why the `dev-main` constraint is required
