### PR TITLE
Rename skill folders to match skill names with consistent prefix

### DIFF
--- a/.claude/skills/laravel-api-resource-patterns/SKILL.md
+++ b/.claude/skills/laravel-api-resource-patterns/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: api-resource-patterns
+name: laravel-api-resource-patterns
 description: Best practices for Laravel API Resources including resource transformation, collection handling, conditional attributes, and relationship loading.
 ---
 

--- a/.claude/skills/laravel-brainstorming/SKILL.md
+++ b/.claude/skills/laravel-brainstorming/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: brainstorming-laravel
+name: laravel-brainstorming
 description: Use when creating or developing Laravel features, before writing code or implementation plans - refines rough ideas into fully-formed Laravel designs through collaborative questioning, alternative exploration, and incremental validation.
 ---
 

--- a/.claude/skills/laravel-systematic-debugging/SKILL.md
+++ b/.claude/skills/laravel-systematic-debugging/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: systematic-debugging-laravel
+name: laravel-systematic-debugging
 description: Systematic debugging process for Laravel applications - ensures root cause investigation before attempting fixes. Use for any Laravel issue (test failures, bugs, unexpected behavior, performance problems).
 ---
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -224,7 +224,7 @@ You need to transform Eloquent models to API responses with proper formatting.
 
 **1. Apply the Skill**
 ```
-> Use api-resource-patterns skill to create post API resources
+> Use laravel-api-resource-patterns skill to create post API resources
 ```
 
 **2. Create Resource**

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -85,13 +85,13 @@ Successfully created a comprehensive collection of Claude Code subagents and ski
    - Red-Green-Refactor cycle
    - Laravel-specific test patterns
 
-2. **brainstorming** (7.8 KB)
+2. **laravel-brainstorming** (7.8 KB)
    - Feature design and planning for Laravel
    - Collaborative questioning approach
    - Laravel pattern exploration
    - Incremental validation
 
-3. **systematic-debugging** (11 KB)
+3. **laravel-systematic-debugging** (11 KB)
    - Four-phase debugging process
    - Laravel-specific debugging techniques
    - Root cause investigation
@@ -104,7 +104,7 @@ Successfully created a comprehensive collection of Claude Code subagents and ski
    - Relationship management
    - Query performance patterns
 
-5. **api-resource-patterns** (6.2 KB)
+5. **laravel-api-resource-patterns** (6.2 KB)
    - API resource transformation
    - Conditional attributes
    - Collection handling with pagination
@@ -189,15 +189,15 @@ laravel-claude-agents/
 │   │   ├── laravel-security-auditor.md
 │   │   └── laravel-testing-expert.md
 │   └── skills/
-│       ├── api-resource-patterns/
+│       ├── laravel-api-resource-patterns/
 │       │   └── SKILL.md
-│       ├── brainstorming/
+│       ├── laravel-brainstorming/
 │       │   └── SKILL.md
 │       ├── eloquent-best-practices/
 │       │   └── SKILL.md
 │       ├── laravel-tdd/
 │       │   └── SKILL.md
-│       └── systematic-debugging/
+│       └── laravel-systematic-debugging/
 │           └── SKILL.md
 ├── CONTRIBUTING.md
 ├── EXAMPLES.md

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ A comprehensive collection of specialized Claude Code subagents and skills desig
 
 **Development Workflows:**
 - **laravel-tdd** - Test-driven development for Laravel with Pest PHP
-- **brainstorming** - Collaborative feature design and planning for Laravel
-- **systematic-debugging** - Systematic debugging process for Laravel applications
+- **laravel-brainstorming** - Collaborative feature design and planning for Laravel
+- **laravel-systematic-debugging** - Systematic debugging process for Laravel applications
 
 **Best Practices:**
 - **eloquent-best-practices** - Eloquent ORM patterns and optimization
-- **api-resource-patterns** - API resource and collection best practices
+- **laravel-api-resource-patterns** - API resource and collection best practices
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ your-project/
 │   │   ├── laravel-testing-expert.md
 │   │   └── laravel-architecture-reviewer.md
 │   └── skills/
-│       ├── systematic-debugging/
+│       ├── laravel-systematic-debugging/
 │       ├── eloquent-best-practices/
-│       ├── api-resource-patterns/
+│       ├── laravel-api-resource-patterns/
 │       ├── laravel-tdd/
-│       └── brainstorming/
+│       └── laravel-brainstorming/
 ```
 
 ## Using with Claude Code

--- a/STATS.md
+++ b/STATS.md
@@ -80,13 +80,13 @@ Located in `.claude/skills/`:
    - Red-Green-Refactor cycle
    - Laravel-specific test patterns
 
-2. **brainstorming/** - 7.8 KB
+2. **laravel-brainstorming/** - 7.8 KB
    - Feature design and planning for Laravel
    - Collaborative questioning approach
    - Laravel pattern exploration
    - Incremental validation
 
-3. **systematic-debugging/** - 11 KB
+3. **laravel-systematic-debugging/** - 11 KB
    - Four-phase debugging process
    - Laravel-specific debugging techniques
    - Root cause investigation
@@ -169,10 +169,10 @@ Located in `.claude/skills/`:
 ## Skills Coverage
 
 ### By Category
-- **Development Methodology:** 2 skills (laravel-tdd, brainstorming)
-- **Debugging Process:** 1 skill (systematic-debugging)
+- **Development Methodology:** 2 skills (laravel-tdd, laravel-brainstorming)
+- **Debugging Process:** 1 skill (laravel-systematic-debugging)
 - **ORM Best Practices:** 1 skill (eloquent-best-practices)
-- **API Patterns:** 1 skill (api-resource-patterns)
+- **API Patterns:** 1 skill (laravel-api-resource-patterns)
 
 ## Content Quality Metrics
 


### PR DESCRIPTION
## Problem

Skill folder names don't match the `name` property defined in their `SKILL.md` files. This mismatch can cause issues with Claude Code skill resolution.

Additionally, some skills use an inconsistent suffix pattern (`brainstorming-laravel`) instead of the prefix pattern (`laravel-*`) used by all agents and other skills.

## Changes

Renamed 3 skill folders and their `name` property to follow the `laravel-` prefix convention:

- `brainstorming/` → `laravel-brainstorming/`
- `systematic-debugging/` → `laravel-systematic-debugging/`
- `api-resource-patterns/` → `laravel-api-resource-patterns/`

Updated all references in README.md, EXAMPLES.md, STATS.md and IMPLEMENTATION_SUMMARY.md.
