### PR TITLE
Fix invalid manifest fields causing installation failure

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -28,7 +28,5 @@
     "blade",
     "scheduling",
     "feature-flags"
-  ],
-  "agents": "./agents/",
-  "skills": "./skills/"
+  ]
 }


### PR DESCRIPTION
Hi,

I tried to install this but got an error. This PR should resolve it.

---

## Summary

- Remove agents and skills fields from plugin.json — these are not valid manifest fields and cause a validation error on install

## Details

Installing this plugin fails with:

> Error: Failed to install: Plugin has an invalid manifest file. Validation errors: agents: Invalid input

Claude Code auto-discovers agents and skills from the agents/ and skills/ directories — they don't need to be declared in the manifest.