### PR TITLE
Fix Claude plugin manifest validation for agents

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -28,7 +28,5 @@
     "blade",
     "scheduling",
     "feature-flags"
-  ],
-  "agents": "./agents/",
-  "skills": "./skills/"
+  ]
 }


### PR DESCRIPTION
## Summary

Removes the `agents` and `skills` fields from `.claude-plugin/plugin.json`.

## Problem

Installing the plugin in Claude Code fails with:

`Validation errors: agents: Invalid input`

## Cause

The manifest currently defines component paths explicitly:

```json
"agents": "./agents/",
"skills": "./skills/"
